### PR TITLE
Convert opgo to assembly and hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,20 @@
-# React + TypeScript + Vite
+# OpGo!!
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+## File formats
 
-Currently, two official plugins are available:
+- .opgo: Default OpGo!! project file. Plain-text instructions in OpGo!! syntax. Lines typically end with `;` as a statement terminator. Saved and opened directly without conversion.
+- .mpc: Legacy 8085 simulator export/import format. When saving with `.mpc`, content is wrapped in the required RTF-like structure for GNUSim8085/Vikas-style tools. When opening `.mpc`, the wrapper is removed to recover instructions.
+- .opg: Custom project extension for branding (alias of `.opgo`). You can rename `.opgo` to `.opg` interchangeably. Both are treated as the same plain-text format.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Export utilities
 
-## Expanding the ESLint configuration
+- Export as .asm: Converts `.opgo` code to standard assembly by line-wise cleanup.
+  - Rule: For each line, remove a single trailing `;` (if present) and trim trailing whitespace.
+  - Output keeps original line order and internal spacing.
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+- Export as .hex: Placeholder machine code export for hardware kits. The current build emits a commented placeholder file until a full assembler is integrated.
 
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+## Notes
 
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
-
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+- Open dialog accepts `.opgo` and `.mpc` files.
+- Save defaults to `.opgo`. If you explicitly choose `.mpc`, conversion to simulator RTF format is applied.

--- a/src/components/FileNameDialog.tsx
+++ b/src/components/FileNameDialog.tsx
@@ -18,7 +18,7 @@ export default function FileNameDialog({
 
   useEffect(() => {
     if (isOpen) {
-      setFileName(currentFileName.replace('.mpc', ''));
+      setFileName(currentFileName.replace('.mpc', '').replace('.opgo', ''));
       setTimeout(() => {
         inputRef.current?.focus();
         inputRef.current?.select();
@@ -30,7 +30,7 @@ export default function FileNameDialog({
     e.preventDefault();
     const trimmed = fileName.trim();
     if (trimmed) {
-      const finalFileName = trimmed.endsWith('.mpc') ? trimmed : `${trimmed}.mpc`;
+      const finalFileName = trimmed.endsWith('.opgo') || trimmed.endsWith('.opg') || trimmed.endsWith('.mpc') ? trimmed : `${trimmed}.opgo`;
       onSave(finalFileName);
     }
   };
@@ -63,7 +63,7 @@ export default function FileNameDialog({
               placeholder="Enter file name"
               autoComplete="off"
             />
-            <p className="text-xs text-gray-500 mt-1">File will be saved as .mpc</p>
+            <p className="text-xs text-gray-500 mt-1">File will be saved as .opgo</p>
           </div>
           <div className="flex justify-end space-x-3">
             <button

--- a/src/components/controlbar.tsx
+++ b/src/components/controlbar.tsx
@@ -44,7 +44,7 @@ import { getInitialFlags, getInitialRegisters, type Registers as RegistersType, 
 
 export default function ControlBar() {
   const [showDropdown, setShowDropdown] = useState(false);
-  const { fileName, hasUnsavedChanges, openFile, saveFile, saveAsFile } = useFileContext();
+  const { fileName, hasUnsavedChanges, openFile, saveFile, saveAsFile, exportAsAsm, exportAsHex } = useFileContext();
 
   const [cpuFlags, setCpuFlags] = useState<FlagsType>(getInitialFlags());
   const currentLineRef = useRef<number>(0);
@@ -88,6 +88,26 @@ export default function ControlBar() {
       setShowDropdown(false);
     } catch (error) {
       console.error('Error saving file as:', error);
+    }
+  };
+
+  const handleExportAsm = async () => {
+    try {
+      const content = await getCurrentContent();
+      await exportAsAsm(content);
+      setShowDropdown(false);
+    } catch (error) {
+      console.error('Error exporting ASM:', error);
+    }
+  };
+
+  const handleExportHex = async () => {
+    try {
+      const content = await getCurrentContent();
+      await exportAsHex(content);
+      setShowDropdown(false);
+    } catch (error) {
+      console.error('Error exporting HEX:', error);
     }
   };
 
@@ -946,7 +966,7 @@ case 'cpi':
                 className="px-10 py-4 hover:bg-green-700 cursor-pointer"
                 onClick={handleOpen}
               >
-                Open (.mpc)
+                Open (.opgo/.opg/.mpc)
               </li>
               <li 
                 className="px-10 py-4 hover:bg-green-700 cursor-pointer"
@@ -958,7 +978,19 @@ case 'cpi':
                 className="px-8 py-4 hover:bg-green-700 cursor-pointer"
                 onClick={handleSaveAs}
               >
-                Save As (.mpc)
+                Save As (.opgo)
+              </li>
+              <li 
+                className="px-8 py-4 hover:bg-green-700 cursor-pointer"
+                onClick={handleExportAsm}
+              >
+                Export as .asm
+              </li>
+              <li 
+                className="px-8 py-4 hover:bg-green-700 cursor-pointer"
+                onClick={handleExportHex}
+              >
+                Export as .hex
               </li>
             </ul>
           </div>


### PR DESCRIPTION
Set `.opgo` as the default file format, add `.opg` support, and implement `.asm` (with conversion rule) and `.hex` export options.

The `.asm` export specifically implements the requested conversion rule: for each line, it removes a trailing semicolon (if present) and trims trailing whitespace, enabling OpGo!! code to be used with other 8085 simulators. The `.hex` export is a placeholder for future integration with a full assembler.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cf7a3a6-2587-4571-bf31-72fe875a0d38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6cf7a3a6-2587-4571-bf31-72fe875a0d38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

