### PR TITLE
Add light theme with matching colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/20.png" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,8 +10,11 @@ import FileNameDialog from "./components/FileNameDialog";
 import InstructionInfo from "./components/InstructionInfo";
 import Profile from "./pages/Profile"; // ✅ import Profile page
 import { FileProvider, useFileContext } from "./contexts/FileContext";
+import { useTheme } from "./contexts/ThemeContext";
 
 function Simulator() {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
   const { showFileNameDialog, setShowFileNameDialog, handleSaveWithName, fileName } =
     useFileContext();
 
@@ -34,19 +37,19 @@ function Simulator() {
   return (
     <>
       <div className="flex flex-row w-full h-[calc(100vh-48px)]">
-        <div className="w-[45%] bg-[#d9d9d9] flex flex-col">
+        <div className={`w-[45%] ${isDark ? 'bg-[#d9d9d9]' : 'bg-white'} flex flex-col`}>
           <ControlBar />
           <InstructionInput />
         </div>
-        <div className="w-[35%] bg-[#3F3F46] flex flex-col">
-          <div className="h-[35%] bg-green-500">
+        <div className={`w-[35%] ${isDark ? 'bg-[#3F3F46]' : 'bg-gray-100'} flex flex-col`}>
+          <div className={`${isDark ? 'bg-green-500' : 'bg-emerald-200'} h-[35%]`}>
             <Flags />
           </div>
-          <div className="h-[65%] bg-green-700">
+          <div className={`${isDark ? 'bg-green-700' : 'bg-emerald-300'} h-[65%]`}>
             <Registers />
           </div>
         </div>
-        <div className="w-[20%] bg-black text-white p-2">
+        <div className={`w-[20%] ${isDark ? 'bg-black text-white' : 'bg-gray-50 text-gray-900'} p-2`}>
           <UserGrid />
         </div>
       </div>

--- a/src/components/controlbar.tsx
+++ b/src/components/controlbar.tsx
@@ -44,8 +44,11 @@ import { executeADDCI } from '../functions/addci';
 import { executeSUBBI } from '../functions/subbi';
 import { executeSETC } from '../functions/setc';
 import { getInitialFlags, getInitialRegisters, type Registers as RegistersType, type Flags as FlagsType } from '../functions/types';
+import { useTheme } from '../contexts/ThemeContext';
 
 export default function ControlBar() {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
   const [showDropdown, setShowDropdown] = useState(false);
   const { fileName, hasUnsavedChanges, openFile, saveFile, saveAsFile, exportAsAsm, exportAsHex } = useFileContext();
 
@@ -967,7 +970,7 @@ case 'cpi':
 
   
   return (
-    <div className="bg-[#d3d3d3] text-white flex items-center justify-between px-4 py-2 text-sm font-medium relative z-25">
+    <div className={`${isDark ? 'bg-[#d3d3d3] text-white' : 'bg-gray-100 text-gray-900'} flex items-center justify-between px-4 py-2 text-sm font-medium relative z-25`}>
       {/* File Menu */}
       <div className="relative">
         <button
@@ -981,28 +984,28 @@ case 'cpi':
         </button>
 
         {showDropdown && (
-          <div className="absolute top-8 left-0 bg-[#3a3a3a] border border-gray-600 rounded shadow-lg z-25">
+          <div className={`${isDark ? 'bg-[#3a3a3a] border border-gray-600' : 'bg-white border border-gray-200'} absolute top-8 left-0 rounded shadow-lg z-25`}>
             <ul className="flex flex-col text-left">
               <li 
-                className="px-10 py-4 hover:bg-green-700 cursor-pointer"
+                className={`${isDark ? 'hover:bg-green-700' : 'hover:bg-gray-100'} px-10 py-4 cursor-pointer`}
                 onClick={handleOpen}
               >
                 Open (.opgo/.opg/.mpc)
               </li>
               <li 
-                className="px-10 py-4 hover:bg-green-700 cursor-pointer"
+                className={`${isDark ? 'hover:bg-green-700' : 'hover:bg-gray-100'} px-10 py-4 cursor-pointer`}
                 onClick={handleSave}
               >
                 Save
               </li>
               <li 
-                className="px-8 py-4 hover:bg-green-700 cursor-pointer"
+                className={`${isDark ? 'hover:bg-green-700' : 'hover:bg-gray-100'} px-8 py-4 cursor-pointer`}
                 onClick={handleSaveAs}
               >
                 Save As (.opgo)
               </li>
               <li 
-                className="px-8 py-4 hover:bg-green-700 cursor-pointer"
+                className={`${isDark ? 'hover:bg-green-700' : 'hover:bg-gray-100'} px-8 py-4 cursor-pointer`}
                 onClick={handleExportAsm}
               >
                 Export as .asm
@@ -1016,17 +1019,17 @@ case 'cpi':
       {/* Action Buttons Styled Like Image */}
       <div className="flex items-center gap-4">
         {/* Stop Button */}
-        <button className="bg-red-600 hover:bg-red-700 rounded-full p-2 flex items-center justify-center cursor-pointer" onClick={handleStop}>
+        <button className={`${isDark ? 'bg-red-600 hover:bg-red-700' : 'bg-red-500 hover:bg-red-600'} rounded-full p-2 flex items-center justify-center cursor-pointer`} onClick={handleStop}>
           <div className="bg-white w-3.5 h-3.5" />
         </button>
 
         {/* Step Into Button */}
-        <button className="bg-[#add8e6] hover:bg-[#9ccbe0] text-black border border-black px-4 py-1 rounded cursor-pointer" onClick={stepInto}>
+        <button className={`${isDark ? 'bg-[#add8e6] hover:bg-[#9ccbe0] text-black border border-black' : 'bg-blue-100 hover:bg-blue-200 text-blue-900 border border-blue-300'} px-4 py-1 rounded cursor-pointer`} onClick={stepInto}>
           Step Into
         </button>
 
         {/* Run Button */}
-        <button className="bg-blue-600 hover:bg-blue-700 rounded-full p-2 flex items-center justify-center cursor-pointer" onClick={handleRun}>
+        <button className={`${isDark ? 'bg-blue-600 hover:bg-blue-700' : 'bg-blue-500 hover:bg-blue-600'} rounded-full p-2 flex items-center justify-center cursor-pointer`} onClick={handleRun}>
           <PlayIcon className="h-4.5 w-4.5 text-white" />
         </button>
 

--- a/src/components/flags.tsx
+++ b/src/components/flags.tsx
@@ -3,8 +3,11 @@ import { gsap } from "gsap"
 import FlagsTitle from "../assets/Flag Title.png"
 import Active from "../assets/Active.png"
 import Unactive from "../assets/Unactive.png"
+import { useTheme } from "../contexts/ThemeContext"
 
 export default function Flags(){
+    const { theme } = useTheme()
+    const isDark = theme === 'dark'
     const [zeroFlag, setZeroFlag] = useState(0)
     const [signFlag, setSignFlag] = useState(0)
     const [carryFlag, setCarryFlag] = useState(0)
@@ -88,33 +91,37 @@ export default function Flags(){
     }, []);
 
     return(
-    <div className="bg-[#2c2c2c] h-full border-3 border-solid border-[#3F3F46] flex flex-col items-center justify-center">
-       <img src={FlagsTitle} className="w-35.5 h-[15%] mt-0" />
+    <div className={`${isDark ? 'bg-[#2c2c2c] border-[#3F3F46]' : 'bg-white border-gray-200'} h-full border-3 border-solid flex flex-col items-center justify-center`}>
+       <img
+         src={isDark ? FlagsTitle : "/assets/Flag Title Light.png"}
+         onError={(e) => { (e.currentTarget as HTMLImageElement).src = FlagsTitle; }}
+         className="w-35.5 h-[15%] mt-0"
+       />
        <div className="flex flex-row w-[100%] h-[85%] justify-center">
             <div className="w-[30%] flex justify-center">
                 <div ref={zeroRef} className="w-[90%]">
                     <img src={zeroFlag === 1 ? Active : Unactive} className="size-15" />
-                    <div className="bg-[#06b6d4] w-[100%] h-[60%] flex flex-col gap-5 items-center">
-                        <h2 className="font-bold text-center pt-2">ZERO</h2>
-                        <h1 className="w-10 h-10 text-center text-white bg-transparent border-2 border-white rounded text-xl font-mono flex items-center justify-center">{zeroFlag}</h1>
+                    <div className={`${isDark ? 'bg-[#06b6d4]' : 'bg-cyan-100'} w-[100%] h-[60%] flex flex-col gap-5 items-center`}>
+                        <h2 className={`font-bold text-center pt-2 ${isDark ? '' : 'text-gray-900'}`}>ZERO</h2>
+                        <h1 className={`w-10 h-10 text-center ${isDark ? 'text-white border-white' : 'text-gray-900 border-gray-400'} bg-transparent border-2 rounded text-xl font-mono flex items-center justify-center`}>{zeroFlag}</h1>
                     </div>
                 </div>
             </div>
             <div className="w-[30%] flex justify-center">
                 <div ref={signRef} className="w-[90%]">
                     <img src={signFlag === 1 ? Active : Unactive} className="size-15" />
-                    <div className="bg-[#f59e0b] w-[100%] h-[60%] flex flex-col gap-5 items-center">
-                        <h2 className="font-bold text-center pt-2">SIGN</h2>
-                        <h1 className="w-10 h-10 text-center text-white bg-transparent border-2 border-white rounded text-xl font-mono flex items-center justify-center">{signFlag}</h1>
+                    <div className={`${isDark ? 'bg-[#f59e0b]' : 'bg-amber-100'} w-[100%] h-[60%] flex flex-col gap-5 items-center`}>
+                        <h2 className={`font-bold text-center pt-2 ${isDark ? '' : 'text-gray-900'}`}>SIGN</h2>
+                        <h1 className={`w-10 h-10 text-center ${isDark ? 'text-white border-white' : 'text-gray-900 border-gray-400'} bg-transparent border-2 rounded text-xl font-mono flex items-center justify-center`}>{signFlag}</h1>
                     </div>
                 </div>
             </div>
             <div className="w-[30%] flex justify-center">
                 <div ref={carryRef} className="w-[90%]">
                     <img src={carryFlag === 1 ? Active : Unactive} className="size-15" />
-                    <div className="bg-[#ec4899] w-[100%] h-[60%] flex flex-col gap-5 items-center">
-                        <h2 className="font-bold text-center pt-2">CARRY</h2>
-                        <h1 className="w-10 h-10 text-center text-white bg-transparent border-2 border-white rounded text-xl font-mono flex items-center justify-center">{carryFlag}</h1>
+                    <div className={`${isDark ? 'bg-[#ec4899]' : 'bg-pink-100'} w-[100%] h-[60%] flex flex-col gap-5 items-center`}>
+                        <h2 className={`font-bold text-center pt-2 ${isDark ? '' : 'text-gray-900'}`}>CARRY</h2>
+                        <h1 className={`w-10 h-10 text-center ${isDark ? 'text-white border-white' : 'text-gray-900 border-gray-400'} bg-transparent border-2 rounded text-xl font-mono flex items-center justify-center`}>{carryFlag}</h1>
                     </div>
                 </div>
             </div>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,7 +1,8 @@
 import LOGO from "../assets/20.png";
 import profile from "../assets/Profile.png";
 import Git from "../assets/Git.png";
-import { InformationCircleIcon } from '@heroicons/react/24/solid';
+import { InformationCircleIcon, MoonIcon, SunIcon } from '@heroicons/react/24/solid';
+import { useTheme } from "../contexts/ThemeContext";
 
 interface NavbarProps {
   onShowInstructions: () => void;
@@ -9,16 +10,30 @@ interface NavbarProps {
 }
 
 export default function Navbar({ onShowInstructions, onProfileClick }: NavbarProps) {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
   return (
-    <div className="bg-[#121212] h-15 flex flex-row items-center px-4">
+    <div className={`${isDark ? 'bg-[#121212]' : 'bg-white border-b border-gray-200'} h-15 flex flex-row items-center px-4`}>
       <img src={LOGO} className="w-29 h-10 mr-4" alt="Logo" />
-      <h2 className="font-bold text-white text-lg">Learn Microprocessor the Easy Way</h2>
+      <h2 className={`font-bold text-lg ${isDark ? 'text-white' : 'text-gray-900'}`}>Learn Microprocessor the Easy Way</h2>
       <div className="ml-auto flex items-center gap-5">
         <InformationCircleIcon
-          className="cursor-pointer text-blue-300 size-10 hover:text-blue-400 transition"
+          className={`${isDark ? 'text-blue-300 hover:text-blue-400' : 'text-blue-600 hover:text-blue-700'} cursor-pointer size-10 transition`}
           onClick={onShowInstructions}
           title="View valid instructions"
         />
+
+        <button
+          onClick={toggleTheme}
+          className={`rounded-md p-1.5 border ${isDark ? 'border-gray-700 hover:bg-white/5' : 'border-gray-300 hover:bg-gray-100'} transition`}
+          title={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+        >
+          {isDark ? (
+            <SunIcon className="size-7 text-yellow-400" />
+          ) : (
+            <MoonIcon className="size-7 text-gray-700" />
+          )}
+        </button>
 
         {/* ✅ Switch to Profile page */}
         <img

--- a/src/components/register.tsx
+++ b/src/components/register.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { gsap } from "gsap";
 import RegTitle from "../assets/Register Title.png"
 import type { Registers as RegistersType } from "../functions/types";
+import { useTheme } from "../contexts/ThemeContext";
 
 interface RegisterData {
   A: [string, string];
@@ -14,6 +15,8 @@ interface RegisterData {
 }
 
 export default function Registers() {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
   const [registers, setRegisters] = useState<RegisterData>({
     A: ["0", "0"],
     B: ["0", "0"],
@@ -107,9 +110,9 @@ export default function Registers() {
   }) => (
     <div 
       ref={(el) => { registerRefs.current[letter] = el; }}
-      className={`${isFullWidth ? 'w-full' : 'w-1/2'} h-20 flex items-center justify-center px-4 ${color} border-2 border-gray-300 transition-colors duration-200`}
+      className={`${isFullWidth ? 'w-full' : 'w-1/2'} h-20 flex items-center justify-center px-4 ${color} border-2 ${isDark ? 'border-gray-300' : 'border-gray-200'} transition-colors duration-200`}
     >
-      <span className="text-white text-4xl font-bold mr-6">{letter}</span>
+      <span className={`${isDark ? 'text-white' : 'text-gray-900'} text-4xl font-bold mr-6`}>{letter}</span>
       <div className="flex gap-3">
         <input
           type="text"
@@ -118,7 +121,7 @@ export default function Registers() {
             const val = e.target.value.toUpperCase().replace(/[^0-9A-F]/g, '').slice(0, 1);
             updateRegister(letter as keyof RegisterData, 0, val);
           }}
-          className="w-10 h-10 text-center text-white bg-transparent border-2 border-white rounded text-xl font-mono transition-colors duration-200 hover:bg-white/10"
+          className={`w-10 h-10 text-center ${isDark ? 'text-white border-white hover:bg-white/10' : 'text-gray-900 border-gray-400 hover:bg-gray-100'} bg-transparent border-2 rounded text-xl font-mono transition-colors duration-200`}
           maxLength={1}
         />
         <input
@@ -128,7 +131,7 @@ export default function Registers() {
             const val = e.target.value.toUpperCase().replace(/[^0-9A-F]/g, '').slice(0, 1);
             updateRegister(letter as keyof RegisterData, 1, val);
           }}
-          className="w-10 h-10 text-center text-white bg-transparent border-2 border-white rounded text-xl font-mono transition-colors duration-200 hover:bg-white/10"
+          className={`w-10 h-10 text-center ${isDark ? 'text-white border-white hover:bg-white/10' : 'text-gray-900 border-gray-400 hover:bg-gray-100'} bg-transparent border-2 rounded text-xl font-mono transition-colors duration-200`}
           maxLength={1}
         />
       </div>
@@ -136,14 +139,18 @@ export default function Registers() {
   );
 
   return (
-    <div className="bg-[#2c2c2c] h-full border-3 border-solid border-[#3F3F46] flex flex-col items-center justify-center p-3 pb-2 pt-0">
-      <img src={RegTitle} className="w-45.5 h-[10%]" />
+    <div className={`${isDark ? 'bg-[#2c2c2c] border-[#3F3F46]' : 'bg-white border-gray-200'} h-full border-3 border-solid flex flex-col items-center justify-center p-3 pb-2 pt-0`}>
+      <img
+        src={isDark ? RegTitle : "/assets/Register Title Light.png"}
+        onError={(e) => { (e.currentTarget as HTMLImageElement).src = RegTitle; }}
+        className="w-45.5 h-[10%]"
+      />
 
       <div className="w-full max-w-md space-y-2">
         <RegisterBlock 
           letter="A" 
           values={registers.A} 
-          color="bg-blue-800" 
+          color={`${isDark ? 'bg-blue-800' : 'bg-blue-100'}`} 
           isFullWidth={true}
         />
         
@@ -151,12 +158,12 @@ export default function Registers() {
           <RegisterBlock 
             letter="B" 
             values={registers.B} 
-            color="bg-purple-400" 
+            color={`${isDark ? 'bg-purple-400' : 'bg-purple-100'}`} 
           />
           <RegisterBlock 
             letter="C" 
             values={registers.C} 
-            color="bg-cyan-400" 
+            color={`${isDark ? 'bg-cyan-400' : 'bg-cyan-100'}`} 
           />
         </div>
         
@@ -164,12 +171,12 @@ export default function Registers() {
           <RegisterBlock 
             letter="D" 
             values={registers.D} 
-            color="bg-orange-500" 
+            color={`${isDark ? 'bg-orange-500' : 'bg-orange-100'}`} 
           />
           <RegisterBlock 
             letter="E" 
             values={registers.E} 
-            color="bg-pink-500" 
+            color={`${isDark ? 'bg-pink-500' : 'bg-pink-100'}`} 
           />
         </div>
         
@@ -177,12 +184,12 @@ export default function Registers() {
           <RegisterBlock 
             letter="H" 
             values={registers.H} 
-            color="bg-blue-500" 
+            color={`${isDark ? 'bg-blue-500' : 'bg-blue-100'}`} 
           />
           <RegisterBlock 
             letter="L" 
             values={registers.L} 
-            color="bg-green-500" 
+            color={`${isDark ? 'bg-green-500' : 'bg-green-100'}`} 
           />
         </div>
       </div>

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,47 @@
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+
+type Theme = "dark" | "light";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const stored = typeof window !== "undefined" ? window.localStorage.getItem("theme") : null;
+    return (stored as Theme) || "dark";
+  });
+
+  const setTheme = (next: Theme) => {
+    setThemeState(next);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("theme", next);
+    }
+  };
+
+  const toggleTheme = () => setTheme(theme === "dark" ? "light" : "dark");
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+  }, [theme]);
+
+  const value = useMemo<ThemeContextValue>(() => ({ theme, toggleTheme, setTheme }), [theme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within a ThemeProvider");
+  return ctx;
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { ThemeProvider } from './contexts/ThemeContext.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
Introduce a light theme with a toggle, preserving the existing dark theme as default and supporting light-specific title images.

This PR adds a `ThemeContext` and `ThemeProvider` to manage theme state and persist user preference. Components are updated to apply conditional styling for light mode, while dark mode styles remain unchanged. Placeholders for `Flag Title Light.png` and `Register Title Light.png` are included, which will display the dark versions until the light assets are added.

---
<a href="https://cursor.com/background-agent?bcId=bc-e76adf51-3ce0-40b5-b6d2-86507a3b8d51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e76adf51-3ce0-40b5-b6d2-86507a3b8d51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

